### PR TITLE
Use get_type_hints to resolve to actual type instead of string version.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .mypy_cache
 dist
 __pycache__

--- a/bq_schema/__init__.py
+++ b/bq_schema/__init__.py
@@ -1,4 +1,4 @@
 """
 Define your BigQuery tables as dataclasses.
 """
-__version__ = "0.5.5"
+__version__ = "0.5.6"

--- a/bq_schema/dataclass_converter.py
+++ b/bq_schema/dataclass_converter.py
@@ -25,6 +25,20 @@ def dataclass_to_schema(
 ) -> List[SchemaField]:
     """
     Transfrom a dataclass into a list of SchemaField.
+
+    If you want to transform a dataclass that is not defined in the
+    global scope you need to pass your locals.
+
+    def my_func():
+        @dataclass
+        class Example1:
+            a: int
+
+        @dataclass
+        class Example2:
+            b: Example1
+
+        dataclass_to_schema(Example2, localns=locals())
     """
     if not is_dataclass(dataclass):
         raise TypeError("Not a dataclass.")

--- a/bq_schema/types/type_parser.py
+++ b/bq_schema/types/type_parser.py
@@ -1,15 +1,17 @@
 from typing import Any, Type
 
+from typing_extensions import get_args
+
 _NoneType = type(None)
 
 
 def parse_inner_type_of_list(list_type: Any) -> Type:
-    return list_type.__args__[0]
+    return get_args(list_type)[0]
 
 
 def parse_inner_type_of_optional(optional_type: Any) -> Type:
 
-    args = optional_type.__args__
+    args = get_args(optional_type)
     if not (len(args) == 2 and any(arg is _NoneType for arg in args)):
         raise TypeError(f"Unsupported type: {optional_type}.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ develop = [
 test = [
     "black==20.8b1",
     "isort==5.6.4",
-    "mypy==0.782",
+    "mypy==0.931",
     "pylint==2.6.0",
     "pytest==6.0.2",
     "pytest-cov==2.10.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,6 @@ test = [
     "isort==5.6.4",
     "mypy==0.931",
     "pylint==2.8.3",
-    "pytest==6.0.2",
-    "pytest-cov==2.10.1"
+    "pytest==7.0.1",
+    "pytest-cov==3.0.0"
 ]

--- a/tests/test_dataclass_converter.py
+++ b/tests/test_dataclass_converter.py
@@ -31,7 +31,7 @@ def test_types():
             metadata={"description": "This is a STRUCT field."}
         )
 
-    assert dataclass_to_schema(Schema) == [
+    assert dataclass_to_schema(Schema, localns=locals()) == [
         SchemaField(
             "string_field", "STRING", "REQUIRED", "This is a STRING field.", ()
         ),
@@ -83,7 +83,7 @@ def test_optional_types():
             metadata={"description": "This is a STRUCT field."}
         )
 
-    assert dataclass_to_schema(Schema) == [
+    assert dataclass_to_schema(Schema, localns=locals()) == [
         SchemaField(
             "string_field", "STRING", "NULLABLE", "This is a STRING field.", ()
         ),
@@ -133,7 +133,7 @@ def test_repeated_types():
             metadata={"description": "This is a STRUCT field."}
         )
 
-    assert dataclass_to_schema(Schema) == [
+    assert dataclass_to_schema(Schema, localns=locals()) == [
         SchemaField(
             "string_field", "STRING", "REPEATED", "This is a STRING field.", ()
         ),


### PR DESCRIPTION
If you use from __future__ import annotations the types on the dataclass fields are by default strings and not the actual types. This behaviour will become the standard in python 3.11. Here we use the function get_type_hints to resolve to actual types.