### PR TITLE
Add failing get_type_hints test case

### DIFF
--- a/bq_schema/bigquery_table.py
+++ b/bq_schema/bigquery_table.py
@@ -50,6 +50,6 @@ class BigqueryTable:
         Return the schema as a list of SchemaField.
         """
         if is_dataclass(self.schema):
-            return dataclass_to_schema(cast(Type, self.schema))
+            return dataclass_to_schema(cast(Type, self.schema), localns={})
 
         return cast(List[SchemaField], self.schema)

--- a/tests/migration/test_table_finder.py
+++ b/tests/migration/test_table_finder.py
@@ -10,3 +10,10 @@ def test_table_finder():
     table_names = {t.name for t in find_tables(tables_dir)}
     expected_table_names = {"first_table", "second_table"}
     assert expected_table_names == table_names
+
+def test_table_schema_fields():
+    file_path = pathlib.Path(__file__).parent
+    tables_dir = os.path.join(file_path, "tables")
+    for local_table in find_tables(tables_dir):
+        schema_fields = local_table.get_schema_fields()
+        assert len(schema_fields) > 0


### PR DESCRIPTION
I've added a test case to expose the following error
```
Traceback (most recent call last):
  File "/opt/pyenv/bin/migrate-tables", line 8, in <module>
    sys.exit(cli())
  File "/opt/pyenv/lib/python3.9/site-packages/bq_schema/cli/migrate_tables.py", line 80, in cli
    main(args.project, args.dataset, args.module_path, args.apply, args.validate)
  File "/opt/pyenv/lib/python3.9/site-packages/bq_schema/cli/migrate_tables.py", line 73, in main
    apply_schema_differences(
  File "/opt/pyenv/lib/python3.9/site-packages/bq_schema/migration/schema_diff.py", line 138, in apply_schema_differences
    schema=difference.local_table.get_schema_fields(),
  File "/opt/pyenv/lib/python3.9/site-packages/bq_schema/bigquery_table.py", line 53, in get_schema_fields
    return dataclass_to_schema(cast(Type, self.schema))
  File "/opt/pyenv/lib/python3.9/site-packages/bq_schema/dataclass_converter.py", line 46, in dataclass_to_schema
    type_hints = get_type_hints(dataclass, localns=localns)
  File "/opt/python-3.9.10/lib/python3.9/typing.py", line 1449, in get_type_hints
    base_globals = sys.modules[base.__module__].__dict__
KeyError: 'not_important'
```

This seems to be an issue that was introduced in #15. `get_type_hints` was changed in Python 3.10 to have guards around not finding `not_important` in `sys.modules` [see here](https://github.com/python/cpython/blame/b7c611937704f5e71f6388da8dfb440fecc28306/Lib/typing.py#L1812).

Prior verisons of Python's [typing.py](https://github.com/python/cpython/blob/665a399e1d1b26991988963260f043a63581138f/Lib/typing.py#L1450) do not have this guard which causes the error in question.

I've added a potential fix... but I am uncertain if this is the best way to fix this issue.