### PR TITLE
Update google bigquery dependency to version 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ home-page = "https://github.com/limehome/bq-schema"
 classifiers = ["License :: OSI Approved :: MIT License"]
 description-file = "README.md"
 requires = [
-    "google-cloud-bigquery==1.24.0",
+    "google-cloud-bigquery>=2,<3",
     "dacite==1.5.1"
 ]
 requires-python = ">=3.7"


### PR DESCRIPTION
Version 1.x is deprecated. According to https://googleapis.dev/python/bigquery/latest/UPGRADING.html#id1 the only thing that changes is that you have to use >= python 3.6. Since this library requires 3.7 this is an easy change to make.