### PR TITLE
Fix: table_finder fixed

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,12 +10,13 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
 
-    runs-on: ubuntu-latest
+  build:
     strategy:
       matrix:
+        os: ['ubuntu-latest', 'windows-latest']
         python-version: ['3.7', '3.8', '3.9', '3.10']
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
@@ -31,4 +32,6 @@ jobs:
     - name: Run code checks
       run: |
         inv check-all
-        bash <(curl -s https://codecov.io/bash)
+    - name: codecov
+      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.7' }}
+      run: bash <(curl -s https://codecov.io/bash)

--- a/bq_schema/migration/table_finder.py
+++ b/bq_schema/migration/table_finder.py
@@ -2,6 +2,7 @@ import importlib
 import inspect
 import pkgutil
 import sys
+from os import path
 from typing import Iterator, Optional, Set
 
 from bq_schema.bigquery_table import BigqueryTable
@@ -26,16 +27,16 @@ def _tables_iterator(
     else:
         module_path = current_path[current_path.find(root_path) :]
 
-    sys_path = sys.path[0].replace("/", ".")
+    sys_path = sys.path[0].replace(path.sep, ".")
 
     module_path_to_iterate = module_path
-    module_path = module_path.replace("/", ".")
+    module_path = module_path.replace(path.sep, ".")
     for (_, module_name, is_pkg) in pkgutil.iter_modules([module_path_to_iterate]):
         module_path = module_path.replace(sys_path, "")
         module_path = module_path[1:] if module_path.startswith(".") else module_path
         module = importlib.import_module(f"{module_path}.{module_name}")
         if is_pkg and module.__file__:
-            sub_path = module.__file__.replace("/__init__.py", "")
+            sub_path = module.__file__.replace(f"{path.sep}__init__.py", "")
             yield from _tables_iterator(root_path, sub_path)
 
         for attribute_name in dir(module):

--- a/tests/migration/test_table_finder.py
+++ b/tests/migration/test_table_finder.py
@@ -10,3 +10,11 @@ def test_table_finder():
     table_names = {t.name for t in find_tables(tables_dir)}
     expected_table_names = {"first_table", "second_table"}
     assert expected_table_names == table_names
+
+
+def test_table_schema_fields():
+    file_path = pathlib.Path(__file__).parent
+    tables_dir = os.path.join(file_path, "tables")
+    for local_table in find_tables(tables_dir):
+        schema_fields = local_table.get_schema_fields()
+        assert len(schema_fields) > 0


### PR DESCRIPTION
Not sure of `sys.path`'s first element will return the project root.

`test_table_finder` test for method `table_finder` is tested by running on PyCharm and via terminal.

This solution is not Windows compatible.
