### PR TITLE
Only ignoring direct descendants of ABC

### DIFF
--- a/bq_schema/__init__.py
+++ b/bq_schema/__init__.py
@@ -1,4 +1,4 @@
 """
 Define your BigQuery tables as dataclasses.
 """
-__version__ = "0.6.2"
+__version__ = "0.6.3"

--- a/bq_schema/migration/table_finder.py
+++ b/bq_schema/migration/table_finder.py
@@ -50,8 +50,9 @@ def _tables_iterator(
                 and attribute != BigqueryTable
                 and not (
                     ignore_abstract
-                    and issubclass(attribute, ABC)
-                    and attribute in ABC.__subclasses__()
+                    and attribute
+                    in ABC.__subclasses__()  # only direct descendants are in ABC's subclass list
+                    # , any concrete implementations shouldn't be here
                 )
             ):
 

--- a/bq_schema/migration/table_finder.py
+++ b/bq_schema/migration/table_finder.py
@@ -48,7 +48,11 @@ def _tables_iterator(
                 inspect.isclass(attribute)
                 and issubclass(attribute, BigqueryTable)
                 and attribute != BigqueryTable
-                and not (ignore_abstract and issubclass(attribute, ABC))
+                and not (
+                    ignore_abstract
+                    and issubclass(attribute, ABC)
+                    and attribute in ABC.__subclasses__()
+                )
             ):
 
                 yield attribute()

--- a/tests/migration/tables/abstract_table.py
+++ b/tests/migration/tables/abstract_table.py
@@ -11,3 +11,8 @@ class AbstractTableSchema:
 
 class FirstTable(BigqueryTable, ABC):
     pass
+
+
+class SecondAbstractTable(FirstTable):
+    name = "second_abstract_table"
+    schema = AbstractTableSchema

--- a/tests/migration/test_table_finder.py
+++ b/tests/migration/test_table_finder.py
@@ -10,7 +10,7 @@ def test_table_finder():
     file_path = pathlib.Path(__file__).parent
     tables_dir = os.path.join(file_path, "tables")
     table_names = {t.name for t in find_tables(tables_dir, True)}
-    expected_table_names = {"first_table", "second_table"}
+    expected_table_names = {"first_table", "second_table", "second_abstract_table"}
     assert expected_table_names == table_names
 
 


### PR DESCRIPTION
Fixed logical issue, all descendants of class inheriting from ABC are also subclasses of ABC, meaning that if we change their schemas it is not picked up. However, only direct descendants are a part of ABC's subclasses, therefore we can check there as well. This means that classes which inherit from a class marked as abstract MUST actually implement name/schema.