### PR TITLE
chore(PLAT-1043): Use full length commit SHA for github-actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.7'
     - name: Install dependencies


### PR DESCRIPTION
**Ticket:** https://limehome.atlassian.net/browse/PLAT-1043

Migrating github-action versions to commit SHA versioned ones.

##### What was done:

- Updated actions under `.github/` to use the full length commit SHA instead of tags
  - Keeping the tag as a comment in the end to make it easier to identify the version

- Also upgrading the version of our most used github-actions
  - The idea here is to step out of actions still using node < 22 

##### How should it be tested:

* Confirm that the tests are passing and that all workflows are running properly (also after merging it)
